### PR TITLE
Corrected conditional to not send request with disabled buttons

### DIFF
--- a/webclient/index.html
+++ b/webclient/index.html
@@ -216,7 +216,7 @@
           el[i].ontouchend = (event) => {
             socket.send(JSON.stringify(generateOnRelease(event.target.id, buttonDictionary[event.target.id].id)));
           };
-        } else {
+        } if (buttonDictionary[el[i].id].hold_down == false) {
           el[i].onclick = (event) => {
             socket.send(JSON.stringify(generateTap(event.target.id, buttonDictionary[event.target.id].id)));
           };


### PR DESCRIPTION
`index.html` has a catch all conditional to send a macro event to the server if the button is not a push and hold style button. This included disabled buttons. This corrects that error.