### PR TITLE
Run server through electron

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,7 @@ server_client/.husky/
 
 server_client_old/
 server_client/.vscode/
+
+server/dist/
+server/build/
+server/server.spec

--- a/server_client/src/main/main.ts
+++ b/server_client/src/main/main.ts
@@ -9,7 +9,7 @@
  * `./src/main.js` using webpack. This gives us some performance wins.
  */
 import path from 'path';
-import fs from 'fs';
+import { NetworkInterfaceInfo, networkInterfaces } from 'os';
 import { app, BrowserWindow, shell, ipcMain } from 'electron';
 import { autoUpdater } from 'electron-updater';
 import log from 'electron-log';
@@ -24,6 +24,8 @@ import {
   streamtabWritePagesFile,
 } from './fileManager';
 
+import { server } from './serverManager';
+
 class AppUpdater {
   constructor() {
     log.transports.file.level = 'info';
@@ -33,13 +35,6 @@ class AppUpdater {
 }
 
 let mainWindow: BrowserWindow | null = null;
-
-// TODO: Remove
-ipcMain.on('ipc-example', async (event, arg) => {
-  const msgTemplate = (pingPong: string) => `IPC test: ${pingPong}`;
-  console.log(msgTemplate(arg));
-  event.reply('ipc-example', msgTemplate('pong'));
-});
 
 ipcMain.handle('streamtab-read-config-file', () => {
   return streamtabReadConfigFile();
@@ -63,6 +58,47 @@ ipcMain.handle('streamtab-write-macros-file', (_, macros: string) => {
 
 ipcMain.handle('streamtab-write-pages-file', (_, pages: string) => {
   return streamtabWritePagesFile(pages);
+});
+
+ipcMain.handle('streamtab-start-server', () => {
+  // TODO:need to get config to this executable
+  return server.serverStart();
+});
+
+ipcMain.handle('streamtab-stop-server', () => {
+  return server.serverStop();
+});
+
+ipcMain.handle('streamtab-get-server-status', () => {
+  return {
+    isRunning: server.server !== null,
+    pid: server.pid,
+  };
+});
+
+ipcMain.handle('streamtab-get-server-ip', () => {
+  const nets = networkInterfaces();
+
+  if (!nets) {
+    return null;
+  }
+
+  const results: NetworkInterfaceInfo[][] = [];
+  const objectNets = Object.keys(nets);
+
+  objectNets.forEach((name) => {
+    const net = nets[name];
+    if (net) {
+      results.push(
+        net.filter((details) => details.family === 'IPv4' && !details.internal)
+      );
+    }
+  });
+
+  if (results.length === 0) {
+    return null;
+  }
+  return results[0][0].address;
 });
 
 if (process.env.NODE_ENV === 'production') {

--- a/server_client/src/main/preload.ts
+++ b/server_client/src/main/preload.ts
@@ -1,26 +1,4 @@
-import { contextBridge, ipcRenderer, IpcRendererEvent } from 'electron';
-
-export type Channels = 'ipc-example';
-
-contextBridge.exposeInMainWorld('electron', {
-  ipcRenderer: {
-    sendMessage(channel: Channels, args: unknown[]) {
-      ipcRenderer.send(channel, args);
-    },
-    on(channel: Channels, func: (...args: unknown[]) => void) {
-      const subscription = (_event: IpcRendererEvent, ...args: unknown[]) =>
-        func(...args);
-      ipcRenderer.on(channel, subscription);
-
-      return () => {
-        ipcRenderer.removeListener(channel, subscription);
-      };
-    },
-    once(channel: Channels, func: (...args: unknown[]) => void) {
-      ipcRenderer.once(channel, (_event, ...args) => func(...args));
-    },
-  },
-});
+import { contextBridge, ipcRenderer } from 'electron';
 
 contextBridge.exposeInMainWorld('streamtabAPI', {
   getConfigFile: async () => {
@@ -40,5 +18,17 @@ contextBridge.exposeInMainWorld('streamtabAPI', {
   },
   writePagesFile: async (pages: string) => {
     return ipcRenderer.invoke('streamtab-write-pages-file', pages);
+  },
+  startServer: async () => {
+    return ipcRenderer.invoke('streamtab-start-server');
+  },
+  stopServer: async () => {
+    return ipcRenderer.invoke('streamtab-stop-server');
+  },
+  getServerStatus: async () => {
+    return ipcRenderer.invoke('streamtab-get-server-status');
+  },
+  getServerIp: async () => {
+    return ipcRenderer.invoke('streamtab-get-server-ip');
   },
 });

--- a/server_client/src/main/serverManager.ts
+++ b/server_client/src/main/serverManager.ts
@@ -1,0 +1,62 @@
+import { ChildProcess, spawn } from 'child_process';
+import path from 'path';
+import kill from 'tree-kill';
+import { consoleLog, consoleError } from './logger';
+
+export class ServerInstance {
+  constructor(pid: number, server: ChildProcess | null) {
+    this.pid = pid;
+    this.server = server;
+    this.restarting = false;
+    this.stderr = '';
+    this.stdout = '';
+  }
+
+  serverStart = () => {
+    if (this.pid !== 0) {
+      consoleLog('Server already running');
+      return;
+    }
+    const serverPath = path.join(__dirname, 'server.exe');
+    const server = spawn(serverPath);
+    if (!server.pid) {
+      consoleError(`No PID`);
+      return;
+    }
+    this.pid = server.pid;
+    this.server = server;
+    server.on('exit', (code, signal) => {
+      consoleLog(`Server exited with code ${code} and signal ${signal}`);
+      this.pid = 0;
+      this.server = null;
+    });
+
+    consoleLog(`Server started with PID ${this.pid}`);
+  };
+
+  serverStop = () => {
+    // kill the process + all children
+    if (this.pid === 0) {
+      // no server running
+      return;
+    }
+    consoleLog(`Stopping server with PID ${this.pid}`);
+    kill(this.pid, 'SIGTERM', (err) => {
+      if (err) {
+        consoleError(`Failed to kill server with PID ${this.pid}`);
+      }
+    });
+  };
+
+  pid: number;
+
+  server: ChildProcess | null;
+
+  restarting: boolean;
+
+  stdout: string;
+
+  stderr: string;
+}
+
+export const server = new ServerInstance(0, null);

--- a/server_client/src/renderer/ServerManager.tsx
+++ b/server_client/src/renderer/ServerManager.tsx
@@ -3,22 +3,32 @@ import { useState } from 'react';
 export const ServerManager = () => {
   const [serverRunning, setServerRunning] = useState(false);
   const [serverError, setServerError] = useState<string | null>(null);
-
-  // TODO: In a proper implementation, we'll use Electron to manage the server
-  // and use IPC to query it's status when this component loads.
-  // We'll do this for now though.
+  const [serverPort, setServerPort] = useState(0);
+  const [serverIp, setServerIp] = useState('0.0.0.0');
 
   const startServer = async () => {
-    // This is fake for npw lol
-    setServerRunning(true);
-    setServerError(null);
+    await window.streamtabAPI.startServer();
+    const ip = await window.streamtabAPI.getServerIp();
+    if (ip) {
+      setServerIp(ip);
+    }
+    const port = await window.streamtabAPI.getConfigFile();
+    if (port) {
+      setServerPort(port.PORT);
+    }
   };
 
   const stopServer = async () => {
-    // This is fake for now lol
-    setServerRunning(false);
-    setServerError(null);
+    await window.streamtabAPI.stopServer();
   };
+
+  const getServerStatus = async () => {
+    const status = await window.streamtabAPI.getServerStatus();
+    if (status !== null) {
+      setServerRunning(status.isRunning);
+    }
+  };
+  setInterval(getServerStatus, 500);
 
   return (
     <div>
@@ -36,7 +46,14 @@ export const ServerManager = () => {
           Stop Server
         </button>
       </div>
-      {serverRunning && <div>Server is running</div>}
+      {serverRunning && (
+        <div>
+          Server is running <br /> navigate to
+          http://streamtab.dmaizik.ca/webclient/?ip={serverIp}&port={serverPort}{' '}
+          <br />
+          On another device on the same network to use StreamTab
+        </div>
+      )}
       {serverError && <div>Server error: {serverError}</div>}
     </div>
   );

--- a/server_client/src/renderer/preload.d.ts
+++ b/server_client/src/renderer/preload.d.ts
@@ -1,26 +1,30 @@
-import { Channels } from 'main/preload';
-
 declare global {
   interface Window {
-    electron: {
-      ipcRenderer: {
-        sendMessage(channel: Channels, args: unknown[]): void;
-        on(
-          channel: Channels,
-          func: (...args: unknown[]) => void
-        ): (() => void) | undefined;
-        once(channel: Channels, func: (...args: unknown[]) => void): void;
-      };
-    };
     streamtabAPI: {
-      getConfigFile: () => Promise<string | null>;
+      getConfigFile: () => Promise<Config | null>;
       getMacrosFile: () => Promise<string | null>;
       getPagesFile: () => Promise<string | null>;
       writeConfigFile: (config: string) => Promise<boolean | null>;
       writeMacrosFile: (macros: string) => Promise<boolean | null>;
       writePagesFile: (pages: string) => Promise<boolean | null>;
+      startServer: () => Promise<boolean | null>;
+      stopServer: () => Promise<boolean | null>;
+      getServerStatus: () => Promise<ServerStatus | null>;
+      getServerIp: () => Promise<string | null>;
     };
   }
+}
+
+export interface ServerStatus {
+  isRunning: boolean;
+  pid: number;
+}
+
+export interface Config {
+  PASSWORD: string;
+  PASSWORD_REQUIRED: boolean;
+  USE_SECURE_PROTOCOL: boolean;
+  PORT: number;
 }
 
 export {};


### PR DESCRIPTION
This is very rudimentary, and will def require some cleanup later

This can:
- Start and stop the server. 
  - Tough this will require you to manually compile the python server to an executable and move it to the electron folder
  - The electron app currently has no way to communicate to the python server where the config files are, or what the config is
- Display the status of the server
  - The react app currently pings electron for the status of the app every 500ms, I assume there is a better way to do this, and will have it in a follow up